### PR TITLE
Delete Documentation/PreviousVersions directory

### DIFF
--- a/Documentation/PreviousVersions/emptyDoc
+++ b/Documentation/PreviousVersions/emptyDoc
@@ -1,1 +1,0 @@
-empty doc


### PR DESCRIPTION
removing the folder titled previous versions because we aren't using it. all files have been integrated into either JOSS or the BioRxiv versions.